### PR TITLE
Update Update-CloudflareRecords.ps1

### DIFF
--- a/Update-CloudflareRecords.ps1
+++ b/Update-CloudflareRecords.ps1
@@ -1,36 +1,39 @@
-﻿param(
-    [string[]] $records = @(),
-    [string] $email = "",
-    [string] $key = ""
+param(
+    [string[]] $records = @("<Your FQDN with Cloudflare>"),
+    [string] $email = "<Your Cloudflare logon>",
+    [string] $key = "<Your Cloudflare API key>",
+    [int] $newTtl = "120"
 )
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $authHeaders = @{ "X-Auth-Email" = $email; "X-Auth-Key" = $key }
 
-$newIp = (Resolve-DnsName -Name "o-o.myaddr.l.google.com." -Type TXT).Strings[0]
+$newIp = (ConvertFrom-Json (Invoke-WebRequest -UseBasicParsing -Method Get -Uri "https://api.ipify.org?format=json").Content).ip
 
-$zoneResponseRaw = Invoke-WebRequest -Method Get -Uri "https://api.cloudflare.com/client/v4/zones" -Headers  $authHeaders
+$zoneResponseRaw = Invoke-WebRequest -UseBasicParsing -Method Get -Uri "https://api.cloudflare.com/client/v4/zones" -Headers $authHeaders
 $zoneResponse = ConvertFrom-Json ($zoneResponseRaw).Content
 
 $zoneResponse.result | % {
     $zoneId = $_.id
 
-    $recordResponse = ConvertFrom-Json (Invoke-WebRequest `
+    $recordResponse = ConvertFrom-Json (Invoke-WebRequest -UseBasicParsing `
         -Uri "https://api.cloudflare.com/client/v4/zones/$zoneId/dns_records" `
         -Method Get -Headers  $authHeaders)
 
     $recordResponse.result | % {
         $recordId = $_.id
-        if ($records -NotContains $_.content)
+        if ($records -NotContains $_.name)
         {
             New-Object psobject -Property @{ "name" = $_.name; "response" = $_.content; "action" = "skipped" }
             $action = "skipped"
         }
-        elseif ( ($records -Contains $_.content) -and ($_.Type -eq "A") )
+        elseif ( ($records -Contains $_.name) -and ($_.Type -eq "A") )
         {
             $updateHeaders = $authHeaders.Clone()
             $updateHeaders += @{"Content-Type" = "application/json"}
             try {
-                $updateResponseRaw = Invoke-WebRequest `
+                $updateResponseRaw = Invoke-WebRequest -UseBasicParsing `
                     -Uri "https://api.cloudflare.com/client/v4/zones/$zoneId/dns_records/$recordId" `
                     -Method Put -Headers  $updateHeaders `
                     -Body (ConvertTo-Json `
@@ -39,6 +42,7 @@ $zoneResponse.result | % {
                             "type" = $_.type;
                             "name" = $_.name;
                             "content" = $newIp;
+                            "ttl" = $newTtl;
                         })
             } catch {
                 $exceptionStream = $_.Exception.Response.GetResponseStream()


### PR DESCRIPTION
Fixed Cloudflare API requiring TTL

Fixed IP detection to use ipify

Fixed UseBasicParsing for where IE has been uninstalled

Fixed to check if record actually exist to save bad API calls

Fixed default values to be more clear on what is expected to be input by the user

Fixed compatibility with TLS1.2 required by Cloudflare API